### PR TITLE
NamePrefix and Camelize class-level attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,28 @@ This bundle comes with several attributes that you can use to add mapping to you
 - `#[ReferenceArray(NestedDTO::class)]`: An array of `NestedDTO` will be created using the mapping information contained in `NestedDTO`.
 - `#[ScalarArray("mapped_property_name")]` The column `mapped_property_name` of your result set will be mapped as an array of scalar properties, such as IDs ([see example](tests/Examples/Valid/ScalarArray/ScalarArrayDTO.php)).
 
+If the mapping between result columns and DTO properties is consistent, the following class attributes can be used
+instead of adding `#[Scalar(...)]` to each property:
+
+- `#[NamePrefix('foo_')]`: the columns named `foo_bar` and `foo_baz` will be mapped to `$bar` and `$baz` properties
+  of a DTO class.
+- `#[Camelize]`: the column with snake-case name `foo_bar` will be mapped to `$fooBar` property.
+- If the above two attributes are both present, then `foo_bar_baz` result column will be mapped to `$barBaz` property.
+- Adding `#[Scalar]` attribute to a specific property will override mapping set up on class level.
+
 <a name="complete_example"></a>
 ### Hydrating nested DTOs
 
-Given:
+Given either
 
-- [AuthorDTO](tests/Examples/Valid/ReferenceArray/AuthorDTO.php)
-- [BookDTO](tests/Examples/Valid/ReferenceArray/BookDTO.php)
+- [AuthorDTO](tests/Examples/Valid/ReferenceArray/AuthorDTO.php) (with property-level attributes)
+- [BookDTO](tests/Examples/Valid/ReferenceArray/BookDTO.php) (with property-level attributes)
+
+or
+
+- [AuthorDTO](tests/Examples/Valid/ClassAttributes/AuthorDTO.php) (with class-level attributes)
+- [BookDTO](tests/Examples/Valid/ClassAttributes/BookDTO.php) (with class-level attributes)
+
 
 Calling FlatMapper with the following result set:
 

--- a/src/Mapping/Camelize.php
+++ b/src/Mapping/Camelize.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Pixelshaped\FlatMapperBundle\Mapping;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Camelize
+{
+}

--- a/src/Mapping/NamePrefix.php
+++ b/src/Mapping/NamePrefix.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Pixelshaped\FlatMapperBundle\Mapping;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class NamePrefix
+{
+    public function __construct(
+        public string $prefix
+    ) {}
+}

--- a/tests/Examples/Valid/ClassAttributes/AuthorDTO.php
+++ b/tests/Examples/Valid/ClassAttributes/AuthorDTO.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Pixelshaped\FlatMapperBundle\Tests\Examples\Valid\ClassAttributes;
+
+use Pixelshaped\FlatMapperBundle\Mapping\Identifier;
+use Pixelshaped\FlatMapperBundle\Mapping\NamePrefix;
+use Pixelshaped\FlatMapperBundle\Mapping\ReferenceArray;
+
+#[NamePrefix('author_')]
+class AuthorDTO
+{
+    /**
+     * @param array<BookDTO> $books
+     */
+    public function __construct(
+        #[Identifier]
+        public int $id,
+        public string $name,
+        #[ReferenceArray(BookDTO::class)]
+        public array $books,
+    ) {}
+}

--- a/tests/Examples/Valid/ClassAttributes/BookDTO.php
+++ b/tests/Examples/Valid/ClassAttributes/BookDTO.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Pixelshaped\FlatMapperBundle\Tests\Examples\Valid\ClassAttributes;
+
+use Pixelshaped\FlatMapperBundle\Mapping\Camelize;
+use Pixelshaped\FlatMapperBundle\Mapping\Identifier;
+use Pixelshaped\FlatMapperBundle\Mapping\NamePrefix;
+
+#[NamePrefix('book_')]
+#[Camelize]
+class BookDTO
+{
+    public function __construct(
+        #[Identifier]
+        public int $id,
+        public string $name,
+        public string $publisherName,
+    ) {}
+}

--- a/tests/FlatMapperTest.php
+++ b/tests/FlatMapperTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Pixelshaped\FlatMapperBundle\Exception\MappingException;
 use Pixelshaped\FlatMapperBundle\FlatMapper;
+use Pixelshaped\FlatMapperBundle\Tests\Examples\Valid\ClassAttributes\AuthorDTO as ClassAttributesAuthorDTO;
+use Pixelshaped\FlatMapperBundle\Tests\Examples\Valid\ClassAttributes\BookDTO as ClassAttributesBookDTO;
 use Pixelshaped\FlatMapperBundle\Tests\Examples\Valid\Complex\CustomerDTO;
 use Pixelshaped\FlatMapperBundle\Tests\Examples\Valid\Complex\InvoiceDTO;
 use Pixelshaped\FlatMapperBundle\Tests\Examples\Valid\Complex\ProductDTO;
@@ -91,16 +93,7 @@ class FlatMapperTest extends TestCase
 
     public function testMapValidNestedDTOs(): void
     {
-        $results = [
-            ['author_id' => 1, 'author_name' => 'Alice Brian', 'book_id' => 1, 'book_name' => 'Travelling as a group', 'book_publisher_name' => 'TravelBooks'],
-            ['author_id' => 1, 'author_name' => 'Alice Brian', 'book_id' => 2, 'book_name' => 'My journeys', 'book_publisher_name' => 'Lorem Press'],
-            ['author_id' => 1, 'author_name' => 'Alice Brian', 'book_id' => 3, 'book_name' => 'Coding on the road', 'book_publisher_name' => 'Ipsum Books'],
-            ['author_id' => 2, 'author_name' => 'Bob Schmo', 'book_id' => 1, 'book_name' => 'Travelling as a group', 'book_publisher_name' => 'TravelBooks'],
-            ['author_id' => 2, 'author_name' => 'Bob Schmo', 'book_id' => 4, 'book_name' => 'My best recipes', 'book_publisher_name' => 'Cooking and Stuff'],
-            ['author_id' => 5, 'author_name' => 'Charlie Doe', 'book_id' => null, 'book_name' => null, 'book_publisher_name' => null],
-        ];
-
-        $flatMapperResults = ((new FlatMapper())->map(AuthorDTO::class, $results));
+        $flatMapperResults = ((new FlatMapper())->map(AuthorDTO::class, $this->getResultsForNestedDTOs()));
 
         $bookDto1 = new BookDTO(1, "Travelling as a group", "TravelBooks");
         $bookDto2 = new BookDTO(2, "My journeys", "Lorem Press");
@@ -221,5 +214,41 @@ class FlatMapperTest extends TestCase
             var_export($flatMapperResults, true),
             var_export([], true)
         );
+    }
+
+    public function testMapNestedDTOsWithClassAttributes(): void
+    {
+        $mappedResults = (new FlatMapper())
+            ->map(ClassAttributesAuthorDTO::class, $this->getResultsForNestedDTOs());
+
+        $bookDto1 = new ClassAttributesBookDTO(1, "Travelling as a group", "TravelBooks");
+        $bookDto2 = new ClassAttributesBookDTO(2, "My journeys", "Lorem Press");
+        $bookDto3 = new ClassAttributesBookDTO(3, "Coding on the road", "Ipsum Books");
+        $bookDto4 = new ClassAttributesBookDTO(4, "My best recipes", "Cooking and Stuff");
+
+        $authorDto1 = new ClassAttributesAuthorDTO(1, "Alice Brian", [
+            1 => $bookDto1, 2 => $bookDto2, 3 => $bookDto3
+        ]);
+        $authorDto2 = new ClassAttributesAuthorDTO(2, "Bob Schmo", [
+            1 => $bookDto1, 4 => $bookDto4
+        ]);
+        $authorDto5 = new ClassAttributesAuthorDTO(5, "Charlie Doe", []);
+
+        $this::assertEquals(
+            $mappedResults,
+            [1 => $authorDto1, 2 => $authorDto2, 5 => $authorDto5]
+        );
+    }
+
+    private function getResultsForNestedDTOs(): array
+    {
+        return [
+            ['author_id' => 1, 'author_name' => 'Alice Brian', 'book_id' => 1, 'book_name' => 'Travelling as a group', 'book_publisher_name' => 'TravelBooks'],
+            ['author_id' => 1, 'author_name' => 'Alice Brian', 'book_id' => 2, 'book_name' => 'My journeys', 'book_publisher_name' => 'Lorem Press'],
+            ['author_id' => 1, 'author_name' => 'Alice Brian', 'book_id' => 3, 'book_name' => 'Coding on the road', 'book_publisher_name' => 'Ipsum Books'],
+            ['author_id' => 2, 'author_name' => 'Bob Schmo', 'book_id' => 1, 'book_name' => 'Travelling as a group', 'book_publisher_name' => 'TravelBooks'],
+            ['author_id' => 2, 'author_name' => 'Bob Schmo', 'book_id' => 4, 'book_name' => 'My best recipes', 'book_publisher_name' => 'Cooking and Stuff'],
+            ['author_id' => 5, 'author_name' => 'Charlie Doe', 'book_id' => null, 'book_name' => null, 'book_publisher_name' => null],
+        ];
     }
 }


### PR DESCRIPTION
This implements the new class-level `#[NamePrefix]` and `#[Camelize]` attributes as described in request #17

Additionally, having more than one `#[Identifier]` attribute on DTO class level will cause an exception, as was probably intended.